### PR TITLE
- add appveyor.yml for CI builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,69 @@
+version: 0.6.0.{build}
+image: Visual Studio 2015
+
+
+environment:
+  matrix:
+  - PlatformToolset: v140_xp
+  - PlatformToolset: v120_xp
+
+platform:
+    #- x64
+    - Win32
+
+configuration:
+    - Release
+    - Debug
+
+install:
+    - if "%platform%"=="x64" set archi=amd64
+    - if "%platform%"=="Win32" set archi=x86
+    - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %archi%
+
+build:
+    parallel: true                  # enable MSBuild parallel builds
+    verbosity: minimal
+
+build_script:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - msbuild LuaScript.sln /p:configuration="%configuration%" /p:platform="%platform%" /p:PlatformToolset="%PlatformToolset%"
+
+after_build:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - ps: >-
+
+        if ($env:PLATFORM -eq "x64") {
+            Push-AppveyorArtifact "src\bin\$env:PLATFORM\$env:CONFIGURATION\LuaScript.dll" -FileName LuaScript.dll
+        }
+
+        if ($env:PLATFORM -eq "Win32" ) {
+            Push-AppveyorArtifact "src\bin\$env:CONFIGURATION\LuaScript.dll" -FileName LuaScript.dll
+        }
+
+        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v120_xp") {
+            if($env:PLATFORM -eq "x64"){
+            $ZipFileName = "LuaScript_$($env:APPVEYOR_REPO_TAG_NAME)_x64.zip"
+            7z a $ZipFileName src\bin\$env:PLATFORM\$env:CONFIGURATION\*.dll
+            }
+            if($env:PLATFORM -eq "Win32"){
+            $ZipFileName = "LuaScript_$($env:APPVEYOR_REPO_TAG_NAME)_x86.zip"
+            7z a $ZipFileName src\bin\$env:CONFIGURATION\*.dll
+            }
+        }
+
+artifacts:
+  - path: LuaScript_*.zip
+    name: releases
+
+deploy:
+    provider: GitHub
+    auth_token:
+        secure: !!TODO, see https://www.appveyor.com/docs/deployment/github/#provider-settings!!
+    artifact: releases
+    draft: false
+    prerelease: false
+    force_update: true
+    on:
+        appveyor_repo_tag: true
+        PlatformToolset: v120_xp
+        configuration: Release


### PR DESCRIPTION
- preparation for automatic deployment of releases to github
- prepared for x64, currently disabled
- see e.g. https://ci.appveyor.com/project/chcg/luascript