### PR TITLE
Fix NPP 8.3.3 plugin API compatibility

### DIFF
--- a/src/Dialogs/ConsoleDialog.cpp
+++ b/src/Dialogs/ConsoleDialog.cpp
@@ -108,7 +108,7 @@ INT_PTR CALLBACK ConsoleDialog::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 			return FALSE;
 		case WM_SIZE: {
 			RECT rect = { 0, 0, LOWORD(lParam), HIWORD(lParam) };
-			int h = min(m_sciInput.Call(SCI_GETLINECOUNT), 8) * m_sciInput.Call(SCI_TEXTHEIGHT, 1);
+			int h = static_cast<int>(min(m_sciInput.Call(SCI_GETLINECOUNT), 8) * m_sciInput.Call(SCI_TEXTHEIGHT, 1));
 			MoveWindow((HWND)m_sciOutput.GetID(), 0, 0, rect.right, rect.bottom - h - 14, TRUE);
 			MoveWindow((HWND)m_sciInput.GetID(), 0, rect.bottom - h - 14, rect.right - 50, h + 9, TRUE);
 			m_sciOutput.Call(SCI_DOCUMENTEND);
@@ -169,16 +169,16 @@ INT_PTR CALLBACK ConsoleDialog::run_dlgProc(UINT message, WPARAM wParam, LPARAM 
 							if (scn->linesAdded != 0) {
 								RECT rect;
 								GetClientRect(_hSelf, &rect);
-								int h = min(m_sciInput.Call(SCI_GETLINECOUNT), 8) * m_sciInput.Call(SCI_TEXTHEIGHT, 1);
+								int h = static_cast<int>(min(m_sciInput.Call(SCI_GETLINECOUNT), 8) * m_sciInput.Call(SCI_TEXTHEIGHT, 1));
 								MoveWindow((HWND)m_sciOutput.GetID(), 0, 0, rect.right, rect.bottom - h - 14, TRUE);
 								MoveWindow((HWND)m_sciInput.GetID(), 0, rect.bottom - h - 14, rect.right - 50, h + 9, TRUE);
 								m_sciOutput.Call(SCI_DOCUMENTEND);
 							}
 
 							// Not the most efficient way but by far the easiest to do it here
-							int startLine = 0;
-							int endLine = m_sciInput.Call(SCI_GETLINECOUNT);
-							for (int i = startLine; i < endLine; ++i) {
+							intptr_t startLine = 0;
+							intptr_t endLine = m_sciInput.Call(SCI_GETLINECOUNT);
+							for (intptr_t i = startLine; i < endLine; ++i) {
 								m_sciInput.CallString(SCI_MARGINSETTEXT, i, ">");
 								m_sciInput.Call(SCI_MARGINSETSTYLE, i, STYLE_LINENUMBER);
 							}
@@ -299,8 +299,8 @@ LRESULT CALLBACK ConsoleDialog::inputWndProc(HWND hWnd, UINT uMsg, WPARAM wParam
 }
 
 void ConsoleDialog::runStatement() {
-	int prevLastLine = m_sciOutput.Call(SCI_GETLINECOUNT);
-	int newLastLine = 0;
+	intptr_t prevLastLine = m_sciOutput.Call(SCI_GETLINECOUNT);
+	intptr_t newLastLine = 0;
 
 	Sci_TextRange tr;
 	tr.chrg.cpMin = 0;
@@ -318,7 +318,7 @@ void ConsoleDialog::runStatement() {
 
 	newLastLine = m_sciOutput.Call(SCI_GETLINECOUNT);
 
-	for (int i = prevLastLine; i < newLastLine; ++i) {
+	for (intptr_t i = prevLastLine; i < newLastLine; ++i) {
 		m_sciOutput.CallString(SCI_MARGINSETTEXT, i - 1, ">");
 		m_sciOutput.Call(SCI_MARGINSETSTYLE, i - 1, STYLE_LINENUMBER);
 	}

--- a/src/LuaConsole.cpp
+++ b/src/LuaConsole.cpp
@@ -363,7 +363,7 @@ void LuaConsole::showAutoCompletion() {
 
 		// Back up past the partial word
 		prevCh = static_cast<int>(m_sciInput->Call(SCI_GETCHARAT, curPos - 1 - partialWord.size()));
-		curPos = curPos - static_cast<int>(partialWord.size());
+		curPos = curPos - partialWord.size();
 	}
 
 	if (prevCh == '.' || prevCh == ':') {

--- a/src/LuaScript.cpp
+++ b/src/LuaScript.cpp
@@ -299,13 +299,13 @@ extern "C" __declspec(dllexport) void beNotified(SCNotification *notifyCode) {
 			// Copied from SciTE
 			GUI::ScintillaWindow wEditor;
 			wEditor.SetID(curScintilla);
-			int lineEndStyled = wEditor.Call(SCI_LINEFROMPOSITION, wEditor.Call(SCI_GETENDSTYLED));
-			int endStyled = wEditor.Call(SCI_POSITIONFROMLINE, lineEndStyled);
+			intptr_t lineEndStyled = wEditor.Call(SCI_LINEFROMPOSITION, wEditor.Call(SCI_GETENDSTYLED));
+			intptr_t endStyled = wEditor.Call(SCI_POSITIONFROMLINE, lineEndStyled);
 			StyleWriter styler(wEditor);
 			int styleStart = 0;
 			if (endStyled > 0) styleStart = styler.StyleAt(endStyled - 1);
-			styler.SetCodePage(wEditor.Call(SCI_GETCODEPAGE));
-			LuaExtension::Instance().OnStyle(endStyled, static_cast<int>(notifyCode->position) - endStyled, styleStart, &styler);
+			styler.SetCodePage(static_cast<int>(wEditor.Call(SCI_GETCODEPAGE)));
+			LuaExtension::Instance().OnStyle(endStyled, notifyCode->position - endStyled, styleStart, &styler);
 			styler.Flush();
 			break;
 		}

--- a/src/Npp/Sci_Position.h
+++ b/src/Npp/Sci_Position.h
@@ -18,7 +18,7 @@ typedef ptrdiff_t Sci_Position;
 typedef size_t Sci_PositionU;
 
 // For Sci_CharacterRange  which is defined as long to be compatible with Win32 CHARRANGE
-typedef long Sci_PositionCR;
+typedef intptr_t Sci_PositionCR;
 
 #ifdef _WIN32
 	#define SCI_METHOD __stdcall

--- a/src/NppExtensionAPI.cpp
+++ b/src/NppExtensionAPI.cpp
@@ -39,7 +39,7 @@ sptr_t NppExtensionAPI::Send(NppExtensionAPI::Pane p, unsigned int msg, uptr_t w
 		return scis[p].Call(msg, wParam, lParam);
 }
 
-char *NppExtensionAPI::Range(NppExtensionAPI::Pane p, int start, int end) {
+char *NppExtensionAPI::Range(NppExtensionAPI::Pane p, intptr_t start, intptr_t end) {
 	if (end <= start) return nullptr;
 
 	char *dest = new char[end - start + 1];
@@ -52,14 +52,14 @@ char *NppExtensionAPI::Range(NppExtensionAPI::Pane p, int start, int end) {
 	return dest;
 }
 
-void NppExtensionAPI::Remove(NppExtensionAPI::Pane p, int start, int end) {
+void NppExtensionAPI::Remove(NppExtensionAPI::Pane p, intptr_t start, intptr_t end) {
 	if (end <= start) return;
 
-	int deleteLength = end - start;
+	intptr_t deleteLength = end - start;
 	this->Send(p, SCI_DELETERANGE, start, deleteLength);
 }
 
-void NppExtensionAPI::Insert(NppExtensionAPI::Pane p, int pos, const char *s) {
+void NppExtensionAPI::Insert(NppExtensionAPI::Pane p, intptr_t pos, const char *s) {
 	this->Send(p, SCI_INSERTTEXT, pos, reinterpret_cast<LPARAM>(s));
 }
 

--- a/src/NppExtensionAPI.h
+++ b/src/NppExtensionAPI.h
@@ -61,9 +61,9 @@ public:
 	Pane getCurrentPane();
 
 	sptr_t Send(Pane p, unsigned int msg, uptr_t wParam = 0, sptr_t lParam = 0);
-	char *Range(Pane p, int start, int end);
-	void Remove(Pane p, int start, int end);
-	void Insert(Pane p, int pos, const char *s);
+	char *Range(Pane p, intptr_t start, intptr_t end);
+	void Remove(Pane p, intptr_t start, intptr_t end);
+	void Insert(Pane p, intptr_t pos, const char *s);
 	void SetTextDirection(Pane p, bool rtl);
 	void Trace(const char *s);
 	void TraceError(const char *s);

--- a/src/SciTE/GUI.h
+++ b/src/SciTE/GUI.h
@@ -153,7 +153,7 @@ public:
 	bool CanCall() const {
 		return wid && fn && ptr;
 	}
-	int Call(unsigned int msg, uptr_t wParam=0, sptr_t lParam=0) {
+	intptr_t Call(unsigned int msg, uptr_t wParam=0, sptr_t lParam=0) {
 		switch (msg) {
 		case SCI_CREATEDOCUMENT:
 		case SCI_CREATELOADER:
@@ -179,10 +179,10 @@ public:
 			throw ScintillaFailure(status);
 		return retVal;
 	}
-	int CallPointer(unsigned int msg, uptr_t wParam, void *s) {
+	intptr_t CallPointer(unsigned int msg, uptr_t wParam, void *s) {
 		return Call(msg, wParam, reinterpret_cast<sptr_t>(s));
 	}
-	int CallString(unsigned int msg, uptr_t wParam, const char *s) {
+	intptr_t CallString(unsigned int msg, uptr_t wParam, const char *s) {
 		return Call(msg, wParam, reinterpret_cast<sptr_t>(s));
 	}
 	sptr_t Send(unsigned int msg, uptr_t wParam=0, sptr_t lParam=0);

--- a/src/SciTE/GUI.h
+++ b/src/SciTE/GUI.h
@@ -170,7 +170,7 @@ public:
 		status = fn(ptr, SCI_GETSTATUS, 0, 0);
 		if (status > 0 && status < SC_STATUS_WARN_START)
 			throw ScintillaFailure(status);
-		return static_cast<int>(retVal);
+		return retVal;
 	}
 	sptr_t CallReturnPointer(unsigned int msg, uptr_t wParam=0, sptr_t lParam=0) {
 		sptr_t retVal = fn(ptr, msg, wParam, lParam);

--- a/src/SciTE/LuaExtension.cpp
+++ b/src/SciTE/LuaExtension.cpp
@@ -1896,15 +1896,15 @@ void LuaExtension::CallShortcut(int id) {
 
 // Similar to StyleContext class in Scintilla
 struct StylingContext {
-	unsigned int startPos;
-	int lengthDoc;
+	uintptr_t startPos;
+	intptr_t lengthDoc;
 	int initStyle;
 	StyleWriter *styler;
 
-	unsigned int endPos;
-	unsigned int endDoc;
+	uintptr_t endPos;
+	uintptr_t endDoc;
 
-	unsigned int currentPos;
+	uintptr_t currentPos;
 	bool atLineStart;
 	bool atLineEnd;
 	int state;
@@ -1920,7 +1920,7 @@ struct StylingContext {
 	}
 
 	void Colourize() {
-		int end = currentPos - 1;
+		intptr_t end = currentPos - 1;
 		if (end >= static_cast<int>(endDoc))
 			end = static_cast<int>(endDoc)-1;
 		styler->ColourTo(end, state);
@@ -1981,7 +1981,7 @@ struct StylingContext {
 	void GetNextChar() {
 		lenCurrent = lenNext;
 		lenNext = 1;
-		int nextPos = currentPos + lenCurrent;
+		intptr_t nextPos = currentPos + lenCurrent;
 		unsigned char byteNext = static_cast<unsigned char>(styler->SafeGetCharAt(nextPos));
 		unsigned int nextSlot = (cursorPos + 1) % 3;
 		memcpy(cursor[nextSlot], "\0\0\0\0\0\0\0\0", 8);
@@ -2149,13 +2149,13 @@ struct StylingContext {
 
 	static int Token(lua_State *L) {
 		StylingContext *context = Context(L);
-		int start = context->styler->GetStartSegment();
-		int end = context->currentPos - 1;
-		int len = end - start + 1;
+		intptr_t start = context->styler->GetStartSegment();
+		intptr_t end = context->currentPos - 1;
+		intptr_t len = end - start + 1;
 		if (len <= 0)
 			len = 1;
 		char *sReturn = new char[len + 1];
-		for (int i = 0; i < len; i++) {
+		for (intptr_t i = 0; i < len; i++) {
 			sReturn[i] = context->styler->SafeGetCharAt(start + i);
 		}
 		sReturn[len] = '\0';
@@ -2187,7 +2187,7 @@ struct StylingContext {
 	}
 };
 
-bool LuaExtension::OnStyle(unsigned int startPos, int lengthDoc, int initStyle, StyleWriter *styler) {
+bool LuaExtension::OnStyle(uintptr_t startPos, intptr_t lengthDoc, int initStyle, StyleWriter *styler) {
 	if (luaState) {
 		lua_pushstring(luaState, "Npp_Callbacks");
 		lua_gettable(luaState, LUA_REGISTRYINDEX);

--- a/src/SciTE/LuaExtension.h
+++ b/src/SciTE/LuaExtension.h
@@ -55,7 +55,7 @@ public:
 	void CallShortcut(int id);
 
 	// Scintilla callbacks
-	bool OnStyle(unsigned int startPos, int lengthDoc, int initStyle, StyleWriter *styler);
+	bool OnStyle(uintptr_t startPos, intptr_t lengthDoc, int initStyle, StyleWriter *styler);
 	bool OnChar(const SCNotification *sc);
 	bool OnSavePointReached(const SCNotification *sc);
 	bool OnSavePointLeft(const SCNotification *sc);

--- a/src/SciTE/StyleWriter.cpp
+++ b/src/SciTE/StyleWriter.cpp
@@ -24,7 +24,7 @@ bool TextReader::InternalIsLeadByte(char ch) const {
 	return GUI::IsDBCSLeadByte(codePage, ch);
 }
 
-void TextReader::Fill(int position) {
+void TextReader::Fill(intptr_t position) {
 	if (lenDoc == -1)
 		lenDoc = sw.Call(SCI_GETTEXTLENGTH, 0, 0);
 	startPos = position - slopSize;
@@ -48,30 +48,30 @@ bool TextReader::Match(int pos, const char *s) {
 	return true;
 }
 
-int TextReader::StyleAt(int position) {
+int TextReader::StyleAt(intptr_t position) {
 	return static_cast<unsigned char>(sw.Call(SCI_GETSTYLEAT, position, 0));
 }
 
-int TextReader::GetLine(int position) {
+intptr_t TextReader::GetLine(intptr_t position) {
 	return sw.Call(SCI_LINEFROMPOSITION, position, 0);
 }
 
-int TextReader::LineStart(int line) {
+intptr_t TextReader::LineStart(intptr_t line) {
 	return sw.Call(SCI_POSITIONFROMLINE, line, 0);
 }
 
-int TextReader::LevelAt(int line) {
-	return sw.Call(SCI_GETFOLDLEVEL, line, 0);
+int TextReader::LevelAt(intptr_t line) {
+	return static_cast<int>(sw.Call(SCI_GETFOLDLEVEL, line, 0));
 }
 
-int TextReader::Length() {
+intptr_t TextReader::Length() {
 	if (lenDoc == -1)
 		lenDoc = sw.Call(SCI_GETTEXTLENGTH, 0, 0);
 	return lenDoc;
 }
 
-int TextReader::GetLineState(int line) {
-	return sw.Call(SCI_GETLINESTATE, line);
+int TextReader::GetLineState(intptr_t line) {
+	return static_cast<int>(sw.Call(SCI_GETLINESTATE, line));
 }
 
 StyleWriter::StyleWriter(GUI::ScintillaWindow &sw_) :
@@ -81,19 +81,19 @@ StyleWriter::StyleWriter(GUI::ScintillaWindow &sw_) :
 	styleBuf[0] = 0;
 }
 
-int StyleWriter::SetLineState(int line, int state) {
-	return sw.Call(SCI_SETLINESTATE, line, state);
+int StyleWriter::SetLineState(intptr_t line, int state) {
+	return static_cast<int>(sw.Call(SCI_SETLINESTATE, line, state));
 }
 
-void StyleWriter::StartAt(unsigned int start, char chMask) {
+void StyleWriter::StartAt(uintptr_t start, char chMask) {
 	sw.Call(SCI_STARTSTYLING, start, chMask);
 }
 
-void StyleWriter::StartSegment(unsigned int pos) {
+void StyleWriter::StartSegment(uintptr_t pos) {
 	startSeg = pos;
 }
 
-void StyleWriter::ColourTo(unsigned int pos, int chAttr) {
+void StyleWriter::ColourTo(uintptr_t pos, int chAttr) {
 	// Only perform styling if non empty range
 	if (pos != startSeg - 1) {
 		if (validLen + (pos - startSeg + 1) >= bufferSize)
@@ -102,7 +102,7 @@ void StyleWriter::ColourTo(unsigned int pos, int chAttr) {
 			// Too big for buffer so send directly
 			sw.Call(SCI_SETSTYLING, pos - startSeg + 1, chAttr);
 		} else {
-			for (unsigned int i = startSeg; i <= pos; i++) {
+			for (uintptr_t i = startSeg; i <= pos; i++) {
 				styleBuf[validLen++] = static_cast<char>(chAttr);
 			}
 		}
@@ -110,7 +110,7 @@ void StyleWriter::ColourTo(unsigned int pos, int chAttr) {
 	startSeg = pos+1;
 }
 
-void StyleWriter::SetLevel(int line, int level) {
+void StyleWriter::SetLevel(intptr_t line, int level) {
 	sw.Call(SCI_SETFOLDLEVEL, line, level);
 }
 

--- a/src/SciTE/StyleWriter.h
+++ b/src/SciTE/StyleWriter.h
@@ -19,17 +19,17 @@ protected:
 	 * and retrieval overhead.
 	 * @a slopSize positions the buffer before the desired position
 	 * in case there is some backtracking. */
-	enum {bufferSize=4000, slopSize=bufferSize/8};
+	enum : intptr_t {bufferSize=4000, slopSize=bufferSize/8};
 	char buf[bufferSize+1];
-	int startPos;
-	int endPos;
+	intptr_t startPos;
+	intptr_t endPos;
 	int codePage;
 
 	GUI::ScintillaWindow &sw;
-	int lenDoc;
+	intptr_t lenDoc;
 
 	bool InternalIsLeadByte(char ch) const;
-	void Fill(int position);
+	void Fill(intptr_t position);
 public:
 	explicit TextReader(GUI::ScintillaWindow &sw_);
 	char operator[](int position) {
@@ -39,7 +39,7 @@ public:
 		return buf[position - startPos];
 	}
 	/** Safe version of operator[], returning a defined value for invalid position. */
-	char SafeGetCharAt(int position, char chDefault=' ') {
+	char SafeGetCharAt(intptr_t position, char chDefault=' ') {
 		if (position < startPos || position >= endPos) {
 			Fill(position);
 			if (position < startPos || position >= endPos) {
@@ -56,12 +56,12 @@ public:
 		codePage = codePage_;
 	}
 	bool Match(int pos, const char *s);
-	int StyleAt(int position);
-	int GetLine(int position);
-	int LineStart(int line);
-	int LevelAt(int line);
-	int Length();
-	int GetLineState(int line);
+	int StyleAt(intptr_t position);
+	intptr_t GetLine(intptr_t position);
+	intptr_t LineStart(intptr_t line);
+	int LevelAt(intptr_t line);
+	intptr_t Length();
+	int GetLineState(intptr_t line);
 };
 
 // Adds methods needed to write styles and folding
@@ -72,17 +72,17 @@ class StyleWriter : public TextReader {
 protected:
 	char styleBuf[bufferSize];
 	int validLen;
-	unsigned int startSeg;
+	uintptr_t startSeg;
 public:
 	explicit StyleWriter(GUI::ScintillaWindow &sw_);
 	void Flush();
-	int SetLineState(int line, int state);
+	int SetLineState(intptr_t line, int state);
 
-	void StartAt(unsigned int start, char chMask=31);
-	unsigned int GetStartSegment() const { return startSeg; }
-	void StartSegment(unsigned int pos);
-	void ColourTo(unsigned int pos, int chAttr);
-	void SetLevel(int line, int level);
+	void StartAt(uintptr_t start, char chMask=31);
+	uintptr_t GetStartSegment() const { return startSeg; }
+	void StartSegment(uintptr_t pos);
+	void ColourTo(uintptr_t pos, int chAttr);
+	void SetLevel(intptr_t line, int level);
 };
 
 #endif


### PR DESCRIPTION
Changed length, line and position variables to (u)intptr_t, to support
files > 2 GB. This was done based on what the compiler complained about
after changing Call functions in ScintillaWindow, so it might not cover
everything.